### PR TITLE
Add navigate.lucuma.xyz environment

### DIFF
--- a/packages/ui/src/assets/environments.json
+++ b/packages/ui/src/assets/environments.json
@@ -43,5 +43,14 @@
     "navigateConfigsURI": "/db",
     "odbURI": "https://lucuma-postgres-odb-staging.herokuapp.com/odb",
     "ssoURI": "https://sso.gpp.lucuma.xyz"
+  },
+  {
+    "hostName": "navigate.lucuma.xyz",
+    "environment": "Gemini Global",
+    "navigateServerURI": "/navigate/graphql",
+    "navigateServerWsURI": "/navigate/ws",
+    "navigateConfigsURI": "/db",
+    "odbURI": "https://lucuma-postgres-odb-staging.herokuapp.com/odb",
+    "ssoURI": "https://sso.gpp.lucuma.xyz"
   }
 ]


### PR DESCRIPTION
This PR is needed due to lucuma sso restrictions, only a lucuma.xyz domain is accepted to login in the sso system.
Alias for both servers, navigate.cl.gemini.edu and navigate.hi.gemini.edu, were created. Sadly in both cases the alias created was `navigate.lucuma.xyz`.
A new environment was added to handle needed connections.

I recommend to change any local configuracion to use a different url locally, such as `navigate-local.lucuma.xyz`.