### PR TITLE
Production environments should point production odb and sso

### DIFF
--- a/packages/ui/src/assets/environments.json
+++ b/packages/ui/src/assets/environments.json
@@ -32,8 +32,8 @@
     "navigateServerURI": "/navigate/graphql",
     "navigateServerWsURI": "/navigate/ws",
     "navigateConfigsURI": "/db",
-    "odbURI": "https://lucuma-postgres-odb-staging.herokuapp.com/odb",
-    "ssoURI": "https://sso-test.gpp.gemini.edu"
+    "odbURI": "https://lucuma-postgres-odb-production.herokuapp.com/odb",
+    "ssoURI": "https://sso.gpp.gemini.edu"
   },
   {
     "hostName": "navigate.cl.gemini.edu",
@@ -41,7 +41,7 @@
     "navigateServerURI": "/navigate/graphql",
     "navigateServerWsURI": "/navigate/ws",
     "navigateConfigsURI": "/db",
-    "odbURI": "https://lucuma-postgres-odb-staging.herokuapp.com/odb",
-    "ssoURI": "https://sso-test.gpp.gemini.edu"
+    "odbURI": "https://lucuma-postgres-odb-production.herokuapp.com/odb",
+    "ssoURI": "https://sso.gpp.gemini.edu"
   }
 ]


### PR DESCRIPTION
`navigate-test` servers are ready in both sites.
Now the production servers can be pointed to odb and sso production versions.