### PR TITLE
Fix instrument import modal duplicate selection

### DIFF
--- a/packages/ui/src/gql/ApolloConfigs.ts
+++ b/packages/ui/src/gql/ApolloConfigs.ts
@@ -136,9 +136,6 @@ function createClient() {
         GuideAlarm: {
           keyFields: ['wfs'],
         },
-        InstrumentConfig: {
-          keyFields: ['name', 'wfs'],
-        },
       },
     }),
   });

--- a/packages/ui/src/gql/configs/Instrument.ts
+++ b/packages/ui/src/gql/configs/Instrument.ts
@@ -1,4 +1,4 @@
-import { useLazyQuery, useMutation, useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import type { OptionsOf } from '@gql/util';
 
 import { graphql } from './gen';
@@ -11,12 +11,11 @@ const GET_DISTINCT_INSTRUMENTS = graphql(`
   }
 `);
 
-export function useGetDistinctInstruments() {
-  const [queryFunction] = useLazyQuery(GET_DISTINCT_INSTRUMENTS, {
+export function useDistinctInstruments(options: OptionsOf<typeof GET_DISTINCT_INSTRUMENTS> = {}) {
+  return useQuery(GET_DISTINCT_INSTRUMENTS, {
     context: { clientName: 'navigateConfigs' },
+    ...options,
   });
-
-  return queryFunction;
 }
 
 const GET_DISTINCT_PORTS = graphql(`
@@ -27,12 +26,11 @@ const GET_DISTINCT_PORTS = graphql(`
   }
 `);
 
-export function useGetDistinctPorts() {
-  const [queryFunction] = useLazyQuery(GET_DISTINCT_PORTS, {
+export function useDistinctPorts(options: OptionsOf<typeof GET_DISTINCT_PORTS> = {}) {
+  return useQuery(GET_DISTINCT_PORTS, {
     context: { clientName: 'navigateConfigs' },
+    ...options,
   });
-
-  return queryFunction;
 }
 
 export const GET_INSTRUMENTS = graphql(`
@@ -52,12 +50,11 @@ export const GET_INSTRUMENTS = graphql(`
   }
 `);
 
-export function useGetInstruments() {
-  const [queryFunction] = useLazyQuery(GET_INSTRUMENTS, {
+export function useInstruments(options: OptionsOf<typeof GET_INSTRUMENTS> = {}) {
+  return useQuery(GET_INSTRUMENTS, {
     context: { clientName: 'navigateConfigs' },
+    ...options,
   });
-
-  return queryFunction;
 }
 
 export const GET_INSTRUMENT = graphql(`

--- a/packages/ui/src/gql/odb/Observation.ts
+++ b/packages/ui/src/gql/odb/Observation.ts
@@ -1,4 +1,5 @@
-import { useLazyQuery } from '@apollo/client';
+import { useLazyQuery, useQuery } from '@apollo/client';
+import type { OptionsOf } from '@gql/util';
 
 import { graphql } from './gen';
 
@@ -65,9 +66,10 @@ const GET_OBSERVATIONS_BY_STATE = graphql(`
   }
 `);
 
-export function useGetObservationsByState() {
-  return useLazyQuery(GET_OBSERVATIONS_BY_STATE, {
+export function useObservationsByState(options: OptionsOf<typeof GET_OBSERVATIONS_BY_STATE>) {
+  return useQuery(GET_OBSERVATIONS_BY_STATE, {
     context: { clientName: 'odb' },
+    ...options,
   });
 }
 


### PR DESCRIPTION
Remove the `keyFields` configuration for `InstrumentConfig` that was trying to be too clever for it's own good. Also cleans up the import modals to reduce the usage of `useEffect` and instead use the `useQuery` hooks directly.
