### PR TITLE
Remove old observation reference from current configuration

### DIFF
--- a/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
@@ -45,7 +45,7 @@ export function Catalog() {
         obsTitle: selectedTarget.name,
         obsSubtitle: '',
         obsInstrument: selectedTarget.instrument,
-        obsReference: undefined,
+        obsReference: '',
       },
       async onCompleted() {
         setCatalogVisible(false);


### PR DESCRIPTION
Pretty small change to overwrite the reference value from the previous observation if importing a target from the local catalog