### PR TITLE
Add test for Slew button mutation and return promises for react attributes

### DIFF
--- a/eslint.config.shared.js
+++ b/eslint.config.shared.js
@@ -31,6 +31,16 @@ export default config(
       'simple-import-sort/exports': 'error',
       'simple-import-sort/imports': 'error',
 
+      // Allow passing `() => Promise<void>` to a React prop that expects `() => void`. Mostly for Primereact
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        {
+          checksVoidReturn: {
+            attributes: false,
+          },
+        },
+      ],
+
       eqeqeq: 'error',
     },
     plugins: {

--- a/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
@@ -28,7 +28,7 @@ export function Catalog() {
 
   const updateLoading = updateConfigLoading || removeCreateLoading || targetsLoading || updateRotatorLoading;
 
-  function updateTarget() {
+  async function updateTarget() {
     if (!selectedTarget) {
       toast?.show({
         severity: 'warn',
@@ -38,7 +38,7 @@ export function Catalog() {
       return;
     }
 
-    void updateConfiguration({
+    await updateConfiguration({
       variables: {
         ...(configuration as ConfigurationType),
         obsId: selectedTarget.id,

--- a/packages/ui/src/components/Contexts/Variables/Modals/OdbImport/OdbImport.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/OdbImport/OdbImport.tsx
@@ -64,7 +64,7 @@ export function OdbImport() {
     wfsTargetsLoading ||
     resetInstrumentsLoading;
 
-  const updateObs = useCallback(() => {
+  const updateObs = useCallback(async () => {
     if (!selectedObservation) {
       toast?.show({
         severity: 'warn',
@@ -73,7 +73,7 @@ export function OdbImport() {
       });
       return;
     }
-    void updateConfiguration({
+    await updateConfiguration({
       variables: {
         ...(configuration as ConfigurationType),
         obsId: selectedObservation.id,

--- a/packages/ui/src/components/Contexts/Variables/Modals/SlewFlags.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/SlewFlags.tsx
@@ -53,8 +53,8 @@ function SlewFlagInput<T extends keyof UpdateSlewFlagsMutationVariables>({
   const id = useId();
   const [updateSlewFlags, { loading: updateLoading }] = useUpdateSlewFlags();
 
-  function updateFlags() {
-    void updateSlewFlags({
+  async function updateFlags() {
+    await updateSlewFlags({
       variables: {
         pk: flags.pk,
         [flag]: !flags[flag],

--- a/packages/ui/src/components/Contexts/Variables/Modals/Target.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/Target.tsx
@@ -35,8 +35,8 @@ export function Target() {
     }
   }, [targetEdit]);
 
-  function updateObservation() {
-    void updateTarget({
+  async function updateObservation() {
+    await updateTarget({
       variables: {
         ...auxTarget,
         coord1: auxTarget.ra ? auxTarget.ra.degrees : auxTarget.az?.degrees,

--- a/packages/ui/src/components/Layout/AcquisitionAdjustmentToast.tsx
+++ b/packages/ui/src/components/Layout/AcquisitionAdjustmentToast.tsx
@@ -84,7 +84,7 @@ function AcquisitionAdjustmentPrompt({ state }: { state: AcquisitionAdjustmentSt
           severity="success"
           label="Accept"
           onClick={() =>
-            void adjustAcquisition({
+            adjustAcquisition({
               variables: {
                 input: {
                   ...input,
@@ -101,7 +101,7 @@ function AcquisitionAdjustmentPrompt({ state }: { state: AcquisitionAdjustmentSt
           severity="secondary"
           label="Cancel"
           onClick={() =>
-            void adjustAcquisition({
+            adjustAcquisition({
               variables: {
                 input: {
                   ...input,

--- a/packages/ui/src/components/Layout/Navbar/Navbar.tsx
+++ b/packages/ui/src/components/Layout/Navbar/Navbar.tsx
@@ -95,7 +95,7 @@ export default function Navbar() {
           className="p-button-text nav-btn"
           buttonClassName={clsx(!user && 'menu-button-not-logged-in')}
           model={items}
-          onClick={() => (!user ? void navigateToSignIn() : undefined)}
+          onClick={() => (!user ? navigateToSignIn() : undefined)}
           dropdownIcon={<ChevronDown size="lg" />}
         ></SplitButton>
       </div>

--- a/packages/ui/src/components/Login/Login.tsx
+++ b/packages/ui/src/components/Login/Login.tsx
@@ -27,13 +27,7 @@ export default function Login() {
               size="large"
             />
           </Link>
-          <Button
-            icon={<Astronaut />}
-            label="Continue as Guest"
-            size="large"
-            onClick={() => void guestLogin()}
-            outlined
-          />
+          <Button icon={<Astronaut />} label="Continue as Guest" size="large" onClick={guestLogin} outlined />
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/Panels/Guider/Alarms/Alarms.tsx
+++ b/packages/ui/src/components/Panels/Guider/Alarms/Alarms.tsx
@@ -37,9 +37,7 @@ export function Alarms() {
   }, [alarms, guideQualities, guideState, toggleGuideAlarm]);
 
   const onUpdateAlarm = useCallback(
-    (variables: UpdateGuideAlarmMutationVariables) => {
-      void updateAlarm({ variables });
-    },
+    (variables: UpdateGuideAlarmMutationVariables) => updateAlarm({ variables }),
     [updateAlarm],
   );
 

--- a/packages/ui/src/components/Panels/Guider/LightPath/LightPath.tsx
+++ b/packages/ui/src/components/Panels/Guider/LightPath/LightPath.tsx
@@ -82,7 +82,7 @@ export function LightPath() {
               loading={loading}
               disabled={disabled}
               label={label}
-              onClick={() => void onClick(label, from, to)}
+              onClick={() => onClick(label, from, to)}
             />
           );
         })}

--- a/packages/ui/src/components/Panels/Guider/Loop/AdaptiveOptics.tsx
+++ b/packages/ui/src/components/Panels/Guider/Loop/AdaptiveOptics.tsx
@@ -15,12 +15,12 @@ export function Altair() {
   const state = data?.altairGuideLoop;
   const [updateAltairGuideLoop, { loading: updateLoading }] = useUpdateAltairGuideLoop();
 
-  function modifyAltairGuideLoop<T extends keyof UpdateAltairGuideLoopMutationVariables>(
+  async function modifyAltairGuideLoop<T extends keyof UpdateAltairGuideLoopMutationVariables>(
     name: T,
     value: NonNullable<UpdateAltairGuideLoopMutationVariables[T]>,
   ) {
     if (state)
-      void updateAltairGuideLoop({
+      await updateAltairGuideLoop({
         variables: {
           pk: state.pk,
           [name]: value,
@@ -123,12 +123,12 @@ export function GeMS() {
   const state = data?.gemsGuideLoop;
   const [updateGemsGuideLoop, { loading: updateLoading }] = useUpdateGemsGuideLoop();
 
-  function modifyGemsGuideLoop<T extends keyof UpdateGemsGuideLoopMutationVariables>(
+  async function modifyGemsGuideLoop<T extends keyof UpdateGemsGuideLoopMutationVariables>(
     name: T,
     value: NonNullable<UpdateGemsGuideLoopMutationVariables[T]>,
   ) {
     if (state)
-      void updateGemsGuideLoop({
+      await updateGemsGuideLoop({
         variables: {
           pk: state.pk,
           [name]: value,

--- a/packages/ui/src/components/Panels/Guider/Loop/Configuration.tsx
+++ b/packages/ui/src/components/Panels/Guider/Loop/Configuration.tsx
@@ -38,9 +38,9 @@ export function Configuration() {
   const [guideDisable, { loading: disableLoading }] = useGuideDisable();
 
   const modifyGuideLoop = useCallback(
-    <T extends keyof UpdateGuideLoopMutationVariables>(name: T, value: UpdateGuideLoopMutationVariables[T]) => {
+    async <T extends keyof UpdateGuideLoopMutationVariables>(name: T, value: UpdateGuideLoopMutationVariables[T]) => {
       if (state.pk)
-        void updateGuideLoop({
+        await updateGuideLoop({
           variables: {
             pk: state.pk,
             [name]: value,
@@ -91,7 +91,7 @@ export function Configuration() {
 
   useEffect(() => {
     if (m2ComaNotAllowed && state.m2ComaEnable) {
-      modifyGuideLoop('m2ComaEnable', false);
+      void modifyGuideLoop('m2ComaEnable', false);
     }
   }, [m2ComaNotAllowed, state.m2ComaEnable, modifyGuideLoop]);
 
@@ -268,7 +268,7 @@ export function Configuration() {
           <Button
             disabled={disabled || enableLoading || disableLoading}
             onClick={() =>
-              void guideEnable({
+              guideEnable({
                 variables: {
                   config: translateStateGuideInput(),
                 },
@@ -277,7 +277,7 @@ export function Configuration() {
           >
             Enable
           </Button>
-          <Button disabled={disabled || enableLoading || disableLoading} onClick={() => void guideDisable()}>
+          <Button disabled={disabled || enableLoading || disableLoading} onClick={() => guideDisable()}>
             Disable
           </Button>
         </div>

--- a/packages/ui/src/components/Panels/Telescope/Systems/AdaptiveOptics.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Systems/AdaptiveOptics.tsx
@@ -17,12 +17,12 @@ export function GeMS({ canEdit }: { canEdit: boolean }) {
   const state = useGemsInstrument().data?.gemsInstrument ?? ({} as GemsInstrumentType);
   const updateGemsInstrument = useUpdateGemsInstrument();
 
-  function modifyGemsInstrument<T extends keyof UpdateGemsInstrumentMutationVariables>(
+  async function modifyGemsInstrument<T extends keyof UpdateGemsInstrumentMutationVariables>(
     name: T,
     value: NonNullable<UpdateGemsInstrumentMutationVariables[T]>,
   ) {
     if (state.pk)
-      void updateGemsInstrument({
+      await updateGemsInstrument({
         variables: {
           pk: state.pk,
           [name]: value,
@@ -67,12 +67,12 @@ export function Altair({ canEdit }: { canEdit: boolean }) {
   const state = useAltairInstrument().data?.altairInstrument ?? ({} as AltairInstrumentType);
   const updateAltairInstrument = useUpdateAltairInstrument();
 
-  function modifyAltairInstrument<T extends keyof UpdateAltairInstrumentMutationVariables>(
+  async function modifyAltairInstrument<T extends keyof UpdateAltairInstrumentMutationVariables>(
     name: T,
     value: UpdateAltairInstrumentMutationVariables[T],
   ) {
     if (isNotNullish(value) && state.pk)
-      void updateAltairInstrument({
+      await updateAltairInstrument({
         variables: {
           pk: state.pk,
           [name]: value,

--- a/packages/ui/src/components/Panels/Telescope/Systems/Instrument.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Systems/Instrument.tsx
@@ -58,9 +58,9 @@ export function Instrument({ canEdit }: { canEdit: boolean }) {
     [auxInstrument],
   );
 
-  const onClickSave = useCallback(() => {
+  const onClickSave = useCallback(async () => {
     if (auxInstrument && instrument)
-      void updateInstrument({
+      await updateInstrument({
         variables: {
           ...instrument,
           ...auxInstrument,

--- a/packages/ui/src/components/Panels/Telescope/Systems/Rotator.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Systems/Rotator.tsx
@@ -22,9 +22,9 @@ export function Rotator({ canEdit }: { canEdit: boolean }) {
           value={rotator?.tracking}
           options={['TRACKING', 'FIXED']}
           loading={loading}
-          onChange={(e) => {
+          onChange={async (e) => {
             if (rotator)
-              void updateRotator({
+              await updateRotator({
                 variables: { pk: rotator.pk, tracking: e.target.value as TrackingType },
               });
           }}
@@ -36,9 +36,9 @@ export function Rotator({ canEdit }: { canEdit: boolean }) {
           value={rotator?.angle}
           minFractionDigits={2}
           maxFractionDigits={7}
-          onValueChange={(e) => {
+          onValueChange={async (e) => {
             if (rotator)
-              void updateRotator({
+              await updateRotator({
                 variables: { pk: rotator.pk, angle: e.target.value },
               });
           }}

--- a/packages/ui/src/components/Panels/Telescope/Systems/Subsystems.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Systems/Subsystems.tsx
@@ -6,7 +6,7 @@ import { Button } from 'primereact/button';
 import { Dropdown } from 'primereact/dropdown';
 import { InputNumber } from 'primereact/inputnumber';
 import { Slider } from 'primereact/slider';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { BTN_CLASSES } from '@/Helpers/constants';
 import type { MechanismType } from '@/types';
@@ -63,14 +63,16 @@ export function BotSubsystems({ canEdit }: { canEdit: boolean }) {
 
   const updateMechanism = useUpdateMechanism();
 
-  function modifyMechanism(vars: Omit<UpdateMechanismMutationVariables, 'pk'>) {
-    void updateMechanism({
-      variables: {
-        pk: state.pk,
-        ...vars,
-      },
-    });
-  }
+  const modifyMechanism = useCallback(
+    (vars: Omit<UpdateMechanismMutationVariables, 'pk'>) =>
+      updateMechanism({
+        variables: {
+          pk: state.pk,
+          ...vars,
+        },
+      }),
+    [state.pk, updateMechanism],
+  );
 
   return (
     <div className="bottom">

--- a/packages/ui/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
@@ -14,6 +14,7 @@ import { useInstrumentPort } from '@gql/server/Instrument';
 import { useNavigateState } from '@gql/server/NavigateState';
 import { useRestoreTarget, useSwapTarget } from '@gql/server/TargetSwap';
 import { Button } from 'primereact/button';
+import { useCallback } from 'react';
 
 import { useCanEdit } from '@/components/atoms/auth';
 import { useToast } from '@/Helpers/toast';
@@ -73,7 +74,7 @@ export function TargetSwapButton({
   const label = data?.onSwappedTarget ? 'Point to Base' : 'Point to Guide Star';
   const severity = data?.onSwappedTarget ? 'danger' : undefined;
 
-  const onClick = () => {
+  const onClick = useCallback(async () => {
     if (selectedTarget?.id && instrument && rotator && oiSelected && acInst) {
       // TODO: other inputs for swap/nonswap
       const rotatorInput: RotatorTrackingInput = { ipa: { degrees: rotator.angle }, mode: rotator.tracking };
@@ -101,7 +102,7 @@ export function TargetSwapButton({
           wavelength: { nanometers: selectedTarget.wavelength },
         };
 
-        void restoreTarget({
+        await restoreTarget({
           variables: {
             config: {
               instrument: instrument.name as InstrumentName,
@@ -152,7 +153,7 @@ export function TargetSwapButton({
           // wavelength: {nanometers: } // <- ???
         };
 
-        void swapTarget({
+        await swapTarget({
           variables: {
             swapConfig: {
               acParams: instrumentInput,
@@ -183,7 +184,17 @@ export function TargetSwapButton({
         detail,
       });
     }
-  };
+  }, [
+    acInst,
+    data?.onSwappedTarget,
+    instrument,
+    oiSelected,
+    restoreTarget,
+    rotator,
+    selectedTarget,
+    swapTarget,
+    toast,
+  ]);
 
   return (
     <Button

--- a/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/AcquisitionCamera.tsx
+++ b/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/AcquisitionCamera.tsx
@@ -24,8 +24,8 @@ export default function AcquisitionCamera({ canEdit, ac }: { canEdit: boolean; a
   const onClick = useCallback(
     () =>
       integrating
-        ? void stopObserve({})
-        : void startObserve({
+        ? stopObserve({})
+        : startObserve({
             variables: { period: { milliseconds: exp * 1000 } },
           }),
     [exp, integrating, startObserve, stopObserve],

--- a/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/InstrumentHandset.tsx
+++ b/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/InstrumentHandset.tsx
@@ -37,15 +37,13 @@ export default function InstrumentHandset({ canEdit }: { canEdit: boolean }) {
   const strategy = strategies[alignment];
 
   const handleApply = useCallback(
-    (coords: Coords) => {
-      const offsetInput = strategy.toInput(coords);
-      void adjustOrigin({
+    async (coords: Coords) =>
+      adjustOrigin({
         variables: {
-          offset: offsetInput,
+          offset: strategy.toInput(coords),
           openLoops,
         },
-      });
-    },
+      }),
     [adjustOrigin, openLoops, strategy],
   );
 
@@ -74,9 +72,9 @@ export default function InstrumentHandset({ canEdit }: { canEdit: boolean }) {
             size="small"
             label="Reset"
             disabled={loading || !canEdit}
-            onClick={() => void resetAdjustment({ variables: { openLoops } })}
+            onClick={() => resetAdjustment({ variables: { openLoops } })}
           />
-          <Button size="small" label="Absorb" disabled={loading || !canEdit} onClick={() => void absorbAdjustment()} />
+          <Button size="small" label="Absorb" disabled={loading || !canEdit} onClick={() => absorbAdjustment()} />
         </ButtonGroup>
       </div>
 

--- a/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/PointingHandset.tsx
+++ b/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/PointingHandset.tsx
@@ -31,10 +31,7 @@ export default function PointingHandset({ canEdit }: { canEdit: boolean }) {
   const strategy = strategies[alignment];
 
   const handleApply = useCallback(
-    (coords: Coords) => {
-      const offsetInput = strategy.toInput(coords);
-      void adjustPointing({ variables: { offset: offsetInput } });
-    },
+    (coords: Coords) => adjustPointing({ variables: { offset: strategy.toInput(coords) } }),
     [adjustPointing, strategy],
   );
 
@@ -63,12 +60,7 @@ export default function PointingHandset({ canEdit }: { canEdit: boolean }) {
       />
       <div className="control-row buttons">
         <ButtonGroup>
-          <Button
-            size="small"
-            label="Reset"
-            onClick={() => void resetLocalAdjustment()}
-            disabled={loading || !canEdit}
-          />
+          <Button size="small" label="Reset" onClick={() => resetLocalAdjustment()} disabled={loading || !canEdit} />
         </ButtonGroup>
       </div>
       <Title title="Guide correction" />
@@ -81,13 +73,8 @@ export default function PointingHandset({ canEdit }: { canEdit: boolean }) {
       />
       <div className="control-row buttons">
         <ButtonGroup>
-          <Button
-            size="small"
-            label="Reset"
-            onClick={() => void resetGuideAdjustment()}
-            disabled={loading || !canEdit}
-          />
-          <Button size="small" label="Absorb" onClick={() => void absorbAdjustment()} disabled={loading || !canEdit} />
+          <Button size="small" label="Reset" onClick={() => resetGuideAdjustment()} disabled={loading || !canEdit} />
+          <Button size="small" label="Absorb" onClick={() => absorbAdjustment()} disabled={loading || !canEdit} />
         </ButtonGroup>
       </div>
     </div>

--- a/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/TargetsHandset.tsx
+++ b/packages/ui/src/components/Panels/WavefrontSensors/AcquisitionCamera/TargetsHandset.tsx
@@ -57,16 +57,14 @@ export default function TargetsHandset({ canEdit }: { canEdit: boolean }) {
   const strategy = strategies[alignment];
 
   const handleApply = useCallback(
-    (coords: Coords) => {
-      const offsetInput = strategy.toInput(coords);
-      void adjustTarget({
+    (coords: Coords) =>
+      adjustTarget({
         variables: {
           target: selectedTarget,
-          offset: offsetInput,
+          offset: strategy.toInput(coords),
           openLoops,
         },
-      });
-    },
+      }),
     [adjustTarget, openLoops, selectedTarget, strategy],
   );
 
@@ -93,13 +91,13 @@ export default function TargetsHandset({ canEdit }: { canEdit: boolean }) {
             size="small"
             label="Reset"
             disabled={loading || !canEdit}
-            onClick={() => void resetOffset({ variables: { openLoops, target: selectedTarget } })}
+            onClick={() => resetOffset({ variables: { openLoops, target: selectedTarget } })}
           />
           <Button
             size="small"
             label="Absorb"
             disabled={loading || !canEdit}
-            onClick={() => void absorbOffset({ variables: { target: selectedTarget } })}
+            onClick={() => absorbOffset({ variables: { target: selectedTarget } })}
           />
         </ButtonGroup>
       </div>

--- a/packages/ui/src/components/Panels/WavefrontSensors/WavefrontSensor/WavefrontSensor.tsx
+++ b/packages/ui/src/components/Panels/WavefrontSensors/WavefrontSensor/WavefrontSensor.tsx
@@ -83,8 +83,8 @@ function OiwfsObserveButton({ freq, canEdit }: { freq: number; canEdit: boolean 
   const onClick = useCallback(
     () =>
       integrating
-        ? void stopObserve({})
-        : void startObserve({
+        ? stopObserve({})
+        : startObserve({
             variables: { period: { milliseconds: (1 / freq) * 1000 } },
           }),
     [freq, integrating, startObserve, stopObserve],
@@ -134,7 +134,7 @@ function TakeSkyButton({ freq, wfs, canEdit }: { freq: number; wfs: GuideProbe; 
   const [takeSky, { loading: takeSkyLoading }] = useTakeSky();
 
   const onClick = useCallback(
-    () => void takeSky({ variables: { wfs, period: { milliseconds: (1 / freq) * 1000 } } }),
+    () => takeSky({ variables: { wfs, period: { milliseconds: (1 / freq) * 1000 } } }),
     [freq, takeSky, wfs],
   );
 

--- a/packages/ui/src/gql/configs/Target.ts
+++ b/packages/ui/src/gql/configs/Target.ts
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { graphql } from './gen';
 import type { Target } from './gen/graphql';
 
-const GET_TARGETS = graphql(`
+export const GET_TARGETS = graphql(`
   query getTargets {
     targets {
       pk

--- a/packages/ui/src/gql/server/Buttons.test.tsx
+++ b/packages/ui/src/gql/server/Buttons.test.tsx
@@ -1,0 +1,213 @@
+import { GET_CONFIGURATION } from '@gql/configs/Configuration';
+import { GET_INSTRUMENT } from '@gql/configs/Instrument';
+import { GET_ROTATOR } from '@gql/configs/Rotator';
+import { GET_TARGETS } from '@gql/configs/Target';
+import type { MockedResponseOf } from '@gql/util';
+import type { VariablesOf } from '@graphql-typed-document-node/core';
+
+import { renderWithContext } from '@/test/render';
+
+import { Slew, SLEW_MUTATION } from './Buttons';
+import { GET_INSTRUMENT_PORT } from './Instrument';
+
+describe(Slew.name, () => {
+  it('should call slew mutation when pressed', async () => {
+    const sut = renderWithContext(<Slew label="Slew Telescope" />, {
+      mocks: [configurationMock, instrumentPortMock, rotatorMock, instrumentMock, getTargetsMock, slewMutationMock],
+    });
+    await sut.getByRole('button').click();
+
+    expect(slewMutationMock.variableMatcher).toHaveBeenCalledOnce();
+    const variables = slewMutationMock.variableMatcher.mock.calls[0]?.[0] as VariablesOf<typeof SLEW_MUTATION>;
+    expect(variables).toMatchInlineSnapshot(`
+      {
+        "config": {
+          "instParams": {
+            "agName": "ACQ_CAM",
+            "focusOffset": {
+              "micrometers": 0,
+            },
+            "iaa": {
+              "degrees": 0,
+            },
+            "origin": {
+              "x": {
+                "micrometers": 0,
+              },
+              "y": {
+                "micrometers": 0,
+              },
+            },
+          },
+          "instrument": "ACQ_CAM",
+          "rotator": {
+            "ipa": {
+              "degrees": 0,
+            },
+            "mode": "TRACKING",
+          },
+          "sourceATarget": {
+            "azel": undefined,
+            "id": "t-4e16",
+            "name": "WG  22",
+            "sidereal": {
+              "dec": {
+                "dms": "-49:48:00.219525",
+              },
+              "epoch": "J2000.000",
+              "ra": {
+                "hms": "12:38:49.781122",
+              },
+            },
+            "wavelength": {
+              "nanometers": 630,
+            },
+          },
+        },
+        "obsId": "o-3580",
+        "slewOptions": {
+          "autoparkAowfs": false,
+          "autoparkGems": true,
+          "autoparkOiwfs": false,
+          "autoparkPwfs1": false,
+          "autoparkPwfs2": true,
+          "resetPointing": true,
+          "shortcircuitMountFilter": true,
+          "shortcircuitTargetFilter": false,
+          "stopGuide": true,
+          "zeroChopThrow": true,
+          "zeroGuideOffset": false,
+          "zeroInstrumentOffset": true,
+          "zeroMountDiffTrack": true,
+          "zeroMountOffset": true,
+          "zeroSourceDiffTrack": true,
+          "zeroSourceOffset": true,
+        },
+      }
+    `);
+  });
+});
+
+const configurationMock = {
+  request: {
+    query: GET_CONFIGURATION,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      configuration: {
+        pk: 2,
+        selectedTarget: 8,
+        selectedOiTarget: null,
+        selectedP1Target: null,
+        selectedP2Target: null,
+        oiGuidingType: 'NORMAL',
+        p1GuidingType: 'NORMAL',
+        p2GuidingType: 'NORMAL',
+        obsTitle: 'WG  22',
+        obsId: 'o-3580',
+        obsInstrument: 'GMOS_SOUTH',
+        obsSubtitle: null,
+        obsReference: 'G-2025A-0159-D-0433',
+      },
+    },
+  },
+} satisfies MockedResponseOf<typeof GET_CONFIGURATION>;
+
+const instrumentPortMock = {
+  request: { query: GET_INSTRUMENT_PORT },
+  maxUsageCount: Infinity,
+  variableMatcher: () => true,
+  result: {
+    data: {
+      instrumentPort: 3,
+    },
+  },
+} satisfies MockedResponseOf<typeof GET_INSTRUMENT_PORT>;
+
+const rotatorMock = {
+  request: {
+    query: GET_ROTATOR,
+    variables: {},
+  },
+  result: {
+    data: {
+      rotator: {
+        pk: 1,
+        angle: 0,
+        tracking: 'TRACKING',
+      },
+    },
+  },
+} satisfies MockedResponseOf<typeof GET_ROTATOR>;
+
+const instrumentMock = {
+  request: {
+    query: GET_INSTRUMENT,
+  },
+  maxUsageCount: 5,
+  variableMatcher: () => true,
+  result: {
+    data: {
+      instrument: {
+        pk: 27,
+        name: 'ACQ_CAM',
+        iaa: 0,
+        issPort: 1,
+        focusOffset: 0,
+        wfs: 'NONE',
+        originX: 0,
+        originY: 0,
+        ao: false,
+        extraParams: {},
+      },
+    },
+  },
+} satisfies MockedResponseOf<typeof GET_INSTRUMENT>;
+
+const getTargetsMock = {
+  request: {
+    query: GET_TARGETS,
+  },
+  result: {
+    data: {
+      targets: [
+        {
+          pk: 8,
+          id: 't-4e16',
+          name: 'WG  22',
+          ra: {
+            degrees: 189.7074213416667,
+            hms: '12:38:49.781122',
+          },
+          dec: {
+            degrees: 310.1999390236111,
+            dms: '-49:48:00.219525',
+          },
+          az: null,
+          el: null,
+          magnitude: 13.792915,
+          band: 'G',
+          epoch: 'J2000.000',
+          type: 'SCIENCE',
+          wavelength: 630,
+          createdAt: '2025-07-22T14:13:04.094Z',
+        },
+      ],
+    },
+  },
+} satisfies MockedResponseOf<typeof GET_TARGETS>;
+
+const slewMutationMock = {
+  request: {
+    query: SLEW_MUTATION,
+  },
+  variableMatcher: vi.fn().mockReturnValue(true),
+  result: vi.fn().mockReturnValue({
+    data: {
+      slew: {
+        result: 'SUCCESS',
+      },
+    },
+  }),
+} satisfies MockedResponseOf<typeof SLEW_MUTATION>;

--- a/packages/ui/src/gql/server/Buttons.tsx
+++ b/packages/ui/src/gql/server/Buttons.tsx
@@ -44,7 +44,7 @@ function MutationButton<T extends DocumentNode>({
   });
 
   return (
-    <Button {...props} onClick={() => void mutationFunction({ variables })} loading={props.loading || loading}>
+    <Button {...props} onClick={() => mutationFunction({ variables })} loading={props.loading || loading}>
       {icons?.length && <span className="mutation-button-icons">{icons}</span>}
       <span className="p-button-label">{label}</span>
     </Button>
@@ -155,7 +155,7 @@ export function OiwfsPark(props: ButtonProps) {
 }
 
 // SLEW
-const SLEW_MUTATION = graphql(`
+export const SLEW_MUTATION = graphql(`
   mutation runSlew($slewOptions: SlewOptionsInput!, $config: TcsConfigInput!, $obsId: ObservationId) {
     slew(slewOptions: $slewOptions, config: $config, obsId: $obsId) {
       result


### PR DESCRIPTION
- Test for the Slew button mutation to ensure it works correctly.
- Change ESLint rule so that React attributes can accept promises where they might only expect `void`, rather than `Promise<void>`. I noticed in some tests the primereact components were actually awaiting the promises, but the type definitions only accept void.
