### PR TITLE
Change populate command

### DIFF
--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -17,7 +17,7 @@
     "build": "tsc -b",
     "start": "pnpm build && pnpm preview",
     "preview": "node --enable-source-maps ./dist/index.js",
-    "populate": "prisma migrate deploy && prisma db seed",
+    "populate": "prisma migrate reset --force",
     "dev": "node --env-file=.env --watch --enable-source-maps ./dist/index.js",
     "codegen": "graphql-codegen --config tasks/codegen.ts",
     "codegen:watch": "pnpm codegen --watch 'src/graphql/**/*.ts' --watch '../schema/src/*.graphql'",


### PR DESCRIPTION
Migrate reset command is removing everything, running all migrations and seeding the DB again.
--force is required to avoid prompt confirmation.