### PR TITLE
Change selected oi, p1 and p2 target to null if local catalog is used

### DIFF
--- a/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
+++ b/packages/ui/src/components/Contexts/Variables/Modals/Catalog/Catalog.tsx
@@ -46,6 +46,9 @@ export function Catalog() {
         obsSubtitle: '',
         obsInstrument: selectedTarget.instrument,
         obsReference: '',
+        selectedOiTarget: null,
+        selectedP1Target: null,
+        selectedP2Target: null,
       },
       async onCompleted() {
         setCatalogVisible(false);


### PR DESCRIPTION
This change is needed to retrieve the correct instrument configuration, otherwise the previous selected target will remain in the DB and the system may think a specific WFS is being used.

https://app.shortcut.com/lucuma/story/6280/loading-zenith-after-an-odb-observation-with-oi-fails